### PR TITLE
First pass at removing inline javascript events and discuss with team

### DIFF
--- a/app/html/login.html
+++ b/app/html/login.html
@@ -10,7 +10,7 @@
 		<header></header>
 		<div class="formDiv">
 			<h1>Openwireless</h1>
-			<form onsubmit="return login();" method="POST">
+			<form>
 				<input type="text" placeholder="Username" id="username" required/><br>
 				<input type="password" placeholder="Password" id="password" required/><br>
 				<input type="submit" value="Submit"/>

--- a/app/js/openWireless.js
+++ b/app/js/openWireless.js
@@ -1,77 +1,79 @@
 var authorizationToken = getSysauthFromCookie(document.cookie);	
 
-function getSysauthFromCookie(cookieString) {
-	var sysauthPairs = cookieString.split(";");
-	var lastCookieValue = sysauthPairs[sysauthPairs.length - 1].split("=");
-	return lastCookieValue[1];
-};
-	
 function login() {
-	var username = $('#username').val();
-	var password = $('#password').val();
+  var form = $('form');
+  var username = $('#username');
+  var password = $('#password');
 
-    if($("#username").val() == " ") {
-        alert("Please enter a username!");
-        $("#username").focus();
-        return true;
+
+  form.on('submit', function(event){
+    event.preventDefault();
+    if(isEmpty(username.val())) {
+      alert("Please enter a username!");
+      username.focus();
+    }
+    if(isEmpty(password.val())){
+      alert("Please enter a password!");
+      password.focus();
     }
 
-    if($("#password").val() == " ") {
-        alert("Please enter a password!");
-        $("#password").focus();
-        return true;
+    var authRequest = createJsonRequest("login", [username.val(), password.val()])
+    createAjaxRequest("http://192.168.1.1/cgi-bin/luci/rpc/auth", authRequest, redirectTo("changePassword.html"));
+  });
+};
+
+function redirectTo(url) { window.location.href = url; }
+function isEmpty(value) { return !value || value.length === 0 || value == " " }
+function createAjaxRequest(url, requestData, successFunction) {
+  console.log('here');
+  console.log(successFunction);
+  $.ajax({
+    type: "POST",
+    url: url,
+    contentType: "application/json",
+    dataType: "json",
+    data: JSON.stringify(requestData),
+    success: successFunction,
+    error: function(request, errorType, errorMessage) {
+      console.log('Error: ' + errorType + ': Message : ' + errorMessage);
     }
+  });
+}
 
-	var authRequest = createJsonRequest("login", [username, password])
+function createJsonRequest(method, parameters) {
+  return {
+    "jsonrpc": "2.0",
+    "method": method,
+    "params": parameters,
+    "id": 1
+  }
+}
 
-	function loginSuccess(response) {
-		window.location.href = "changePassword.html";
-	}
-
-	createAjaxRequest("http://192.168.1.1/cgi-bin/luci/rpc/auth", authRequest, loginSuccess);
-	return false;
+function getSysauthFromCookie(cookieString) {
+  var sysauthPairs = cookieString.split(";");
+  var lastCookieValue = sysauthPairs[sysauthPairs.length - 1].split("=");
+  return lastCookieValue[1];
 };
 
 function setSSID() {
   var uciUrl = "http://192.168.1.1/cgi-bin/luci/rpc/uci?auth="+authorizationToken;
-	var newSsid = $('#ssid').val();
+  var newSsid = $('#ssid').val();
 
-	var ssidRequest = createJsonRequest("set", ["wireless.@wifi-iface[0].ssid="+newSsid]);
-	var commitRequest = createJsonRequest("commit", ["wireless"]);
-	var getRequest = createJsonRequest("get", ["wireless.@wifi-iface[0].ssid"]);
+  var ssidRequest = createJsonRequest("set", ["wireless.@wifi-iface[0].ssid="+newSsid]);
+  var commitRequest = createJsonRequest("commit", ["wireless"]);
+  var getRequest = createJsonRequest("get", ["wireless.@wifi-iface[0].ssid"]);
 
-	function getSSID(response){
-		createAjaxRequest(uciUrl, getRequest, function(response){ 
-			$("#updatedSSID").html("SSID updated to " + response.result);
-			$('#ssid').val("");
-		});
-	}
-  
-	function commitSsid() {
-		createAjaxRequest(uciUrl, commitRequest, getSSID);
-	}
+  function getSSID(response){
+    createAjaxRequest(uciUrl, getRequest, function(response){ 
+      $("#updatedSSID").html("SSID updated to " + response.result);
+      $('#ssid').val("");
+    });
+  }
 
-	createAjaxRequest(uciUrl, ssidRequest, commitSsid);
-	return false;
+  function commitSsid() {
+    createAjaxRequest(uciUrl, commitRequest, getSSID);
+  }
+
+  createAjaxRequest(uciUrl, ssidRequest, commitSsid);
+  return false;
 }
-
-function createAjaxRequest(url, requestData, successFunction) {
-	$.ajax({
-		type: "POST",
-		url: url,
-		contentType: "application/json",
-	  dataType: "json",
-		data: JSON.stringify(requestData),
-		success: successFunction
-	});
-}
-
-function createJsonRequest(method, parameters) {
-	return {
-		"jsonrpc": "2.0",
-    "method": method,
-    "params": parameters,
-    "id": 1
-	}
-}
-

--- a/jasmine/index.html
+++ b/jasmine/index.html
@@ -15,6 +15,7 @@
   <script type="text/javascript" src="../app/js/checkPassword.js" data-cover></script>
 
   <!-- include spec files here... -->
+  <script type="text/javascript" src="integration/loginSpec.js"></script>
   <script type="text/javascript" src="integration/openWirelessSpec.js"></script>
   <script type="text/javascript" src="integration/changePasswordSpec.js"></script>
 

--- a/jasmine/integration/loginSpec.js
+++ b/jasmine/integration/loginSpec.js
@@ -1,0 +1,67 @@
+describe("Login page", function() {
+  var username, password, loginForm, ssid, alert_msg, redirect ;
+
+  beforeEach(function() {
+    alert_msg = null;
+    affix('form input#username+input#password+input#ssid');
+    loginForm = $('form');
+    username = $('#username');
+    password = $('#password');
+    ssid     = $('#ssid');
+    window.alert = function(msg){alert_msg = msg;};
+    window.redirectTo = function(url) { redirect = url; }
+    login();
+  });
+
+  describe("Login page", function() {
+    it("should alert the user when username field is empty", function() {
+      username.val(" ");
+      password.val("password");
+      loginForm.trigger('submit');
+      expect(alert_msg).toEqual("Please enter a username!");
+    });
+
+    it("should alert the user when password field is empty", function() {
+      username.val("root");
+      password.val(" ");
+      loginForm.trigger('submit');
+      expect(alert_msg).toEqual("Please enter a password!");
+    });
+
+    it("should submit AJAX request to proper URL", function() {
+      spyOn($, "ajax");
+      username.val("root");
+      password.val("password");
+      loginForm.trigger('submit');
+      expect($.ajax.mostRecentCall.args[0]["url"]).toEqual("http://192.168.1.1/cgi-bin/luci/rpc/auth");
+    });
+
+    it("should submit AJAX request with proper data", function() {
+      spyOn($, "ajax");
+      var loginData = "{\"jsonrpc\":\"2.0\",\"method\":\"login\",\"params\":[\"root\",\"asdf1234\"],\"id\":1}";
+      username.val("root");
+      password.val("asdf1234");
+      loginForm.trigger('submit');
+      expect($.ajax.mostRecentCall.args[0]["data"]).toEqual(loginData);
+    });
+
+    it("should redirect the user to the change password page if login was successful", function() {
+      spyOn($, "ajax");
+      username.val("root");
+      password.val("asdf1234");
+      loginForm.trigger('submit');
+      expect(redirect).toEqual("changePassword.html");
+    });
+
+    it("should not redirect user if login fails", function() {
+      spyOn($, "ajax").andCallFake(function(params){
+        params.error({});
+        username.val("baduser");
+        password.val('basspass');
+        loginForm.trigger('submit');
+        expect(redirect).toEqual(null);
+      });
+    });
+  });
+});
+

--- a/jasmine/integration/openWirelessSpec.js
+++ b/jasmine/integration/openWirelessSpec.js
@@ -1,14 +1,17 @@
 describe("All pages", function() {
-  var username, password, loginForm, ssid;
+  var username, password, loginForm, ssid, alert_msg, redirect ;
 
   beforeEach(function() {
-    affix('#test form#loginForm input#username+input#password+input#ssid');
-    loginForm = $('#loginForm');
+    alert_msg = null;
+    affix('form input#username+input#password+input#ssid');
+    loginForm = $('form');
     username = $('#username');
     password = $('#password');
     ssid     = $('#ssid');
-    window.alert = function(){return;};
-    spyOn($, "ajax");
+    window.alert = function(msg){alert_msg = msg;};
+    window.redirectTo = function(url) { redirect = url; }
+    spyOn($, 'ajax');
+    login();
   });
 
   it("should get the last sysauth cookie", function() {
@@ -16,34 +19,6 @@ describe("All pages", function() {
     expect(getSysauthFromCookie(cookie)).toEqual("a1b2c3d456ef7890");
   });
 
-  describe("Login page", function() {
-
-    it("should return true when username field is empty", function() {
-      username.val(" ");
-      expect(login()).toBeTruthy();
-    });
-
-    it("should return true when password field is empty", function() {
-      username.val("root");
-      password.val(" ");
-      expect(login()).toBeTruthy();
-    });
-
-
-    it("should submit AJAX request to proper URL", function() {
-      login();
-      expect($.ajax.mostRecentCall.args[0]["url"]).toEqual("http://192.168.1.1/cgi-bin/luci/rpc/auth");
-    });
-
-    it("should submit AJAX request with proper data", function() {
-      var loginData = "{\"jsonrpc\":\"2.0\",\"method\":\"login\",\"params\":[\"root\",\"asdf1234\"],\"id\":1}";
-      username.val("root");
-      password.val("asdf1234");
-      login();
-
-      expect($.ajax.mostRecentCall.args[0]["data"]).toEqual(loginData);
-    });
-  });
 
   describe("SSID page", function() {
     it("should submit AJAX request to proper URL", function() {


### PR DESCRIPTION
This is a sample of pulling out the javascript into jQuery bound event listeners - instead of using onClick and onSubmit events.

I added a couple of additional specs but tried not to change functionality as you had written it. 

However a few questions 
- if you're using HTML5 required attribute - do we need to have js alert calls?
- right now you didn't have any code if the login call failed. I threw in a small console.log but seems like you would want more.
- also I accidentally left a couple troubleshooting console statements in the code we would want to remove them if we merged.
