### PR TITLE
Remove deadcode in auth_test.py

### DIFF
--- a/test/auth_test.py
+++ b/test/auth_test.py
@@ -59,11 +59,6 @@ class TestAuth(unittest.TestCase):
     self.assertTrue(self.auth.is_password("Passw0rd"))
     self.assertFalse(self.auth.is_password("badpass"))
 
-  def test_password(self):
-    self.auth.save_password("Passw0rd")
-    self.assertTrue(os.path.isfile(os.path.join(self.path, "password")))
-    self.assertTrue(self.auth.is_password("Passw0rd"))
-
   def test_write(self):
     filename = os.path.join(self.path, "foo")
     self.auth.write(filename, "bar")


### PR DESCRIPTION
The correct and new test case is 4 lines up in the same file. However due to redefining the function only the old test case will be tried.
