### PR TITLE
Rename test case to prevent redefining

### DIFF
--- a/test/ssh_key_test.py
+++ b/test/ssh_key_test.py
@@ -102,7 +102,7 @@ Content-Type: application/json
     self.assertFalse(os.path.exists(self.authorized_keys))
     self.assertError('Multiline key not allowed.')
 
-  def test_set_ssh_key_multiline(self):
+  def test_set_ssh_key_invalid(self):
     with self.assertRaises(SystemExit):
       ssh_key.jsonrpc_set_ssh_key({
         'params': [ INVALID_KEY ]


### PR DESCRIPTION
https://github.com/EFForg/OpenWireless/blob/master/test/ssh_key_test.py#L97#L112

The lower function will erroneously redefine `test_set_ssh_key_multiline`.
