### PR TITLE
Revert "Update auth.py"

### DIFF
--- a/routerapi/auth.py
+++ b/routerapi/auth.py
@@ -153,7 +153,7 @@ class Auth:
     if self.rate_limit_remaining() > 0:
       with open(self.password_filename, 'r') as f:
         hashed = f.read().strip()
-      if constant_time_equals(hashed, pbkdf2.crypt(candidate, unicode(hashed))):
+      if hashed == pbkdf2.crypt(candidate, unicode(hashed)):
         return True
       else:
         # Increment rate limit on failures.


### PR DESCRIPTION
Reverts EFForg/OpenWireless#164

Caused a test failure: https://snap-ci.com/EFForg/OpenWireless/branch/master/logs/defaultPipeline/84/python?back_to=build_history

Output:
$ python -m unittest discover -s test/ -p '*_test.py'
# ..........................E.......
## ERROR: test_password (auth_test.TestAuth)

Traceback (most recent call last):
  File "/var/snap-ci/repo/test/auth_test.py", line 59, in test_password
    self.assertTrue(self.auth.is_password("Passw0rd"))
  File "/var/snap-ci/repo/test/../routerapi/auth.py", line 156, in is_password
    if constant_time_equals(hashed, pbkdf2.crypt(candidate, unicode(hashed))):
  File "/var/snap-ci/repo/test/../routerapi/auth.py", line 64, in constant_time_equals
    b = bytearray(b)
TypeError: unicode argument without an encoding
