### PR TITLE
DSA SSH keys say "dss" in them, not "dsa".

### DIFF
--- a/routerapi/ssh_key
+++ b/routerapi/ssh_key
@@ -22,7 +22,7 @@ import common
 import uci
 
 AUTHORIZED_KEYS = os.path.join(common.get_etc(), 'dropbear/authorized_keys')
-KEY_REGEX = r'^ssh-[rd]sa [A-Za-z0-9+/=]{204,760}( .{1,100})?$'
+KEY_REGEX = r'^ssh-(?:rsa|dss) [A-Za-z0-9+/=]{204,760}( .{1,100})?$'
 
 def key_locked(authorized_keys = AUTHORIZED_KEYS):
     """


### PR DESCRIPTION
Rather confusingly, DSA keys [have](http://tools.ietf.org/html/rfc4253#section-6.6) the `ssh-dss` key type, not `ssh-dsa` as one might reasonably expect. Dropbear [can handle](https://github.com/mkj/dropbear/blob/master/ssh.h#L104) these keys with no problem, but there's a bug in the web GUI preventing one from setting such keys. This patch fixes the problem.
