### PR TITLE
Fix dns

### DIFF
--- a/etc/config/firewall
+++ b/etc/config/firewall
@@ -57,6 +57,14 @@ config rule
 
 config rule
 	option target 'ACCEPT'
+	option name 'domain'
+	option proto 'tcp udp'
+	option src '*'
+	option dest '*'
+	option src_port '53'
+
+config rule
+	option target 'ACCEPT'
 	option name 'ntp'
 	option proto 'udp'
 	option dest '*'


### PR DESCRIPTION
This appeared to solve my problem of not being able to resolve mozilla.org. It still doesn't answer the question of why the response to the UDP query gets a 'truncated' flag, but it does allow TCP fallback to work.

Fixes #225.
