### PR TITLE
Remove pbkdf2 from requirements since it's present in the routerapi dir.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 mock==1.0.1
-pbkdf2==1.3
 selenium==2.42.1


### PR DESCRIPTION
Now that we include it directly in routerapi/, it's no longer necessary to install.

Fixes #232
