### PR TITLE
Do a better job of detecting virtualenvs

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -8,13 +8,12 @@
 
 # Install required packages
 npm install
-if [ ! -z "$PYTHONPATH" ] ; then
-  pip install --user -qr requirements.txt
+if [ -z "$VIRTUAL_ENV" ] ; then
+  USER=--user
 else
-  # When running on snap-ci we are in a --no-site-packages virtualenv,
-  # so pip install --user would fail.
-  pip install -qr requirements.txt
+  USER=
 fi
+pip install $USER -qr requirements.txt
 
 if ! ./make-templates.sh --is-updated ; then
   echo "Error: templates.js out-of-date. Run ./make-templates.sh"


### PR DESCRIPTION
This makes run-tests.sh work correctly if the user has set up a virtualenv but still has PYTHONPATH set.
