### PR TITLE
Update diceware.js

### DIFF
--- a/app/js/diceware.js
+++ b/app/js/diceware.js
@@ -25,7 +25,7 @@ Diceware.prototype.load = function(callback) {
       if (line === '-----BEGIN PGP SIGNATURE-----') {
           break;
       }
-      var myregexp = /^\s*?\d+\s*([^\s]+)\s*?$/;
+      var myregexp = /^\s*\d+\s*([^\s]+)\s*$/;
       var match = myregexp.exec(line);
       if (match != null) {
         // matched text: match[0]


### PR DESCRIPTION
Prevent whitespace bugs when parsing the PGP-signed wordlist. (I used this library separately in another project and ran head-first into this issue.)
