### PR TITLE
Makefile: Wildcard for HANDLEBARS_FILES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 TEMPLATES_JS=app/js/templates.js
-HANDLEBARS_FILES=app/templates/*.handlebars  # Used to generate templates.js
+HANDLEBARS_FILES=$(wildcard app/templates/*.handlebars) # Used to generate templates.js
 
 .PHONY: all
 all: $(TEMPLATES_JS)


### PR DESCRIPTION
Using wildcard command to get all `.handlebar` files.
`TEMPLATES_JS` will be generated again when the `HANDLEBARS_FILES` are newer.
