### PR TITLE
Catch exceptions in update API

### DIFF
--- a/routerapi/check_updates
+++ b/routerapi/check_updates
@@ -14,8 +14,8 @@ try:
       ret = "not-up-to-date"
     else:
       ret = "up-to-date"
-except:
-    # catch exception and return error message
+except OSError:
+    # catch call-errors and return error message
     pass
 finally:
     nullfile.close()

--- a/routerapi/update
+++ b/routerapi/update
@@ -14,6 +14,9 @@ try:
       ret = "update-success" # Should never reach this line of code
     else:
       ret = "update-failure"
+except OSError:
+    # catch call-errors and return error message
+    pass
 finally:
     nullfile.close()
 


### PR DESCRIPTION
`try .. except` was only used to close the file. But in case an error occurs `"error-calling-update"` should be rendered. 
Or am I wrong?
